### PR TITLE
Fix Dbt profile name for asset bundle deployment

### DIFF
--- a/dbt_sql/dbt_profiles/profiles.yml
+++ b/dbt_sql/dbt_profiles/profiles.yml
@@ -1,6 +1,6 @@
 
 # This file defines dbt profiles for deployed dbt jobs.
-my_dbt_project:
+dbt_sql:
    target: dev # default target
    outputs:
 

--- a/dbt_sql/src/models/example/schema.yml
+++ b/dbt_sql/src/models/example/schema.yml
@@ -7,7 +7,7 @@ models:
     columns:
       - name: customer_name
         description: "The name of a customer"
-        tests:
+        data_tests:
           - unique
           - not_null
 
@@ -16,6 +16,6 @@ models:
     columns:
       - name: order_date
         description: "The date on which orders took place"
-        tests:
+        data_tests:
           - unique
           - not_null


### PR DESCRIPTION
Hello Team,

While tinkering with your solution, I've noticed that profiles provided in `dbt_project.yml` and `profiles.yml` do not align. This led to the following error, when deploying dbt using asset bundles:

```
+ dbt deps --target=dev
11:24:02  Running with dbt=1.8.2
11:24:02  Warning: No packages were found in packages.yml
11:24:02  Warning: No packages were found in packages.yml

+ dbt seed --target=dev --vars '{ dev_schema: mateusz_kijewski }'
11:24:05  Running with dbt=1.8.2
11:24:05  Encountered an error:
Runtime Error
  Could not find profile named 'dbt_sql'
```

I have corrected profile name in `profiles.yml` to the name provided in `dbt_project.yml`. Using the opportunity of forking your repo, I've also updated tests configuration in model config as starting of dbt v1.8 it's been raising warnings of configuration change from `tests` to `data_tests` 

```
11:31:34  [WARNING]: Deprecated functionality
The `tests` config has been renamed to `data_tests`. Please see
https://docs.getdbt.com/docs/build/data-tests#new-data_tests-syntax for more
information.
```