### PR TITLE
Add a `contrib` folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,5 @@
 This repository provides Databricks Asset Bundles examples.
 
 To learn more, see:
-* The public preview announcement at 
-https://www.databricks.com/blog/announcing-public-preview-databricks-asset-bundles-apply-software-development-best-practices
+* The launch blog post at https://www.databricks.com/blog/announcing-general-availability-databricks-asset-bundles
 * The docs at https://docs.databricks.com/dev-tools/bundles/index.html

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -1,0 +1,43 @@
+# Contrib Directory
+
+The `contrib` directory contains additional community-contributed examples and resources for Databricks Asset Bundles. These examples may include:
+
+- Custom configurations and extensions
+- Advanced usage patterns
+- Tools or utilities for enhancing Databricks Asset Bundles workflows
+
+## Structure
+
+Each contribution should be organized into its own subdirectory within `contrib/`.
+Templates should go under `contrib/templates/`. For example:
+
+```
+contrib/
+├── awesome-bundle/
+│   ├── README.md
+│   ├── databricks.yml
+│   └── ...
+└── templates/
+    └── awesome-template/
+        ├── README.md
+        ├── databricks_template_schema.json
+        ├── library/
+        │   └── ...
+        └── template/
+            └── ...
+```
+
+## How to Use Contributions
+
+To use or explore a contributed example, navigate to its subdirectory and follow the instructions in its `README.md` file. Each example should provide details on setup, configuration, and usage.
+
+## Contributing
+
+If you would like to add your own examples or resources, please:
+1. Create a new directory under `contrib/` with a descriptive name.
+2. Include a `README.md` file explaining the contribution.
+3. Ensure that any necessary configuration files, scripts, or dependencies are included.
+
+For more information on Databricks Asset Bundles, see:
+- [Public Preview Announcement](https://www.databricks.com/blog/announcing-public-preview-databricks-asset-bundles-apply-software-development-best-practices)
+- [Databricks Asset Bundles Documentation](https://docs.databricks.com/dev-tools/bundles/index.html)

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -39,5 +39,5 @@ If you would like to add your own examples or resources, please:
 3. Ensure that any necessary configuration files, scripts, or dependencies are included.
 
 For more information on Databricks Asset Bundles, see:
-- [Public Preview Announcement](https://www.databricks.com/blog/announcing-public-preview-databricks-asset-bundles-apply-software-development-best-practices)
-- [Databricks Asset Bundles Documentation](https://docs.databricks.com/dev-tools/bundles/index.html)
+- The launch blog post at https://www.databricks.com/blog/announcing-general-availability-databricks-asset-bundles
+- The docs at https://docs.databricks.com/dev-tools/bundles/index.html

--- a/contrib/templates/README.md
+++ b/contrib/templates/README.md
@@ -1,6 +1,6 @@
 # Contrib/Templates directory
 
-This directory community-contributed templates.
+This directory contains community-contributed templates.
 
 See https://github.com/databricks/bundle-examples/blob/main/contrib/README.md for
 about community contributions.

--- a/contrib/templates/README.md
+++ b/contrib/templates/README.md
@@ -1,0 +1,10 @@
+# Contrib/Templates directory
+
+This directory community-contributed templates.
+
+See https://github.com/databricks/bundle-examples/blob/main/contrib/README.md for
+about community contributions.
+
+Looking to contribute? See https://github.com/databricks/cli/tree/main/libs/template/templates
+for inspiration. These are the standard templates that are included with the
+Databricks CLI.

--- a/contrib/templates/README.md
+++ b/contrib/templates/README.md
@@ -2,7 +2,7 @@
 
 This directory contains community-contributed templates.
 
-See https://github.com/databricks/bundle-examples/blob/main/contrib/README.md for
+See https://github.com/databricks/bundle-examples/blob/main/contrib/README.md to learn more
 about community contributions.
 
 Looking to contribute? See https://github.com/databricks/cli/tree/main/libs/template/templates


### PR DESCRIPTION
Adds a `contrib` folder for community-contributed examples.