### PR TITLE
scala-job: 'sbt test' command does not pick up JVM options

### DIFF
--- a/contrib/templates/scala-job/template/{{.project_name}}/build.sbt.tmpl
+++ b/contrib/templates/scala-job/template/{{.project_name}}/build.sbt.tmpl
@@ -22,8 +22,6 @@ assemblyMergeStrategy := {
 }
 
 // to run with new jvm options, a fork is required otherwise it uses same options as sbt process
-run / fork := true
-run / javaOptions += "--add-opens=java.base/java.nio=ALL-UNNAMED"
+fork := true
+javaOptions += "--add-opens=java.base/java.nio=ALL-UNNAMED"
 
-test / fork := true
-test / javaOptions += "--add-opens=java.base/java.nio=ALL-UNNAMED"


### PR DESCRIPTION
The sbt 'test' command did not pick up the "javaOptions" option
from `build.sbt`.

The original problem was this was scoped down to "test" instead of
"Test". Update the sbt options to apply the "javaOptions" and "fork" to
all sbt commands.

Tested by running both "sbt test", "sbt run" and corresponding commands
in the sbt shell.