### PR TITLE
Default logging to System.out not System.err

### DIFF
--- a/contrib/templates/scala-job/template/{{.project_name}}/build.sbt.tmpl
+++ b/contrib/templates/scala-job/template/{{.project_name}}/build.sbt.tmpl
@@ -25,3 +25,5 @@ assemblyMergeStrategy := {
 fork := true
 javaOptions += "--add-opens=java.base/java.nio=ALL-UNNAMED"
 
+// To ensure logs are written to System.out by default and not System.err
+run / javaOptions += "-Dorg.slf4j.simpleLogger.logFile=System.out"

--- a/contrib/templates/scala-job/template/{{.project_name}}/build.sbt.tmpl
+++ b/contrib/templates/scala-job/template/{{.project_name}}/build.sbt.tmpl
@@ -26,4 +26,4 @@ fork := true
 javaOptions += "--add-opens=java.base/java.nio=ALL-UNNAMED"
 
 // To ensure logs are written to System.out by default and not System.err
-run / javaOptions += "-Dorg.slf4j.simpleLogger.logFile=System.out"
+javaOptions += "-Dorg.slf4j.simpleLogger.logFile=System.out"


### PR DESCRIPTION
Currently libraries that log to info are actually directed to System.err by default. This PR fixes it to instead go to [info] instead of [error] when running `sbt run`

```
[info] welcome to sbt 1.10.11 (Homebrew Java 17.0.14)
[info] loading global plugins from /Users/garland.zhang/.sbt/1.0/plugins
[info] loading settings for project fix_logging-build from plugins.sbt...
[info] loading project definition from /Users/garland.zhang/tmp/fix_logging/project
[info] loading settings for project fix_logging from build.sbt...
[info] set current project to fix_logging (in build file:/Users/garland.zhang/tmp/fix_logging/)
[info] compiling 1 Scala source to /Users/garland.zhang/tmp/fix_logging/target/scala-2.12/classes ...
[info] running (fork) com.examples.Main 
[info] Hello, World!
[info] Running outside Databricks
[info] [main] INFO Debug mode disabled. Enable with the VM option -Darrow.memory.debug.allocator=true.
[info] [main] INFO allocation manager type not specified, using netty as the default type
[info] [main] INFO Using DefaultAllocationManager at memory/DefaultAllocationManagerFactory.class
[info] [grpc-default-executor-0] INFO Trying pat auth
```

