### PR TITLE
Default to serverless for job deployment in scala job template

### DIFF
--- a/contrib/templates/scala-job/library/template_variables.tmpl
+++ b/contrib/templates/scala-job/library/template_variables.tmpl
@@ -3,7 +3,7 @@
 {{- end }}
 
 {{ define `dbr_version` -}}
-    16.2
+    16.3
 {{- end }}
 
 {{ define `scala_major_minor_version` -}}

--- a/contrib/templates/scala-job/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/contrib/templates/scala-job/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -6,17 +6,15 @@ resources:
       name: {{.project_name}}
       tasks:
         - task_key: main_task
-          job_cluster_key: {{.project_name}}_job_cluster
           spark_jar_task:
             main_class_name: {{template `main_class_name` .}}
           libraries:
             - jar: ../{{template `jar_path` .}}
-      job_clusters:
-        - job_cluster_key: {{.project_name}}_job_cluster
-          new_cluster:
-            spark_version: {{template `dbr_version` .}}.x-scala{{template `scala_major_minor_version` .}}
-            node_type_id: i3.xlarge  # Default instance type (can be changed)
-            autoscale:
-              min_workers: 1
-              max_workers: 4
-            data_security_mode: USER_ISOLATION
+      queue:
+        enabled: true
+      environments:
+        - environment_key: default
+          spec:
+            client: "3"
+            jar_dependencies:
+                - {{.artifacts_dest_path}}/${bundle.name}/${bundle.target}/${workspace.current_user.short_name}

--- a/contrib/templates/scala-job/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/contrib/templates/scala-job/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -14,4 +14,4 @@ resources:
           spec:
             client: "3"
             jar_dependencies:
-                - {{.artifacts_dest_path}}/${bundle.name}/${bundle.target}/${workspace.current_user.short_name}/.internal/{{template `jar_path` .}}
+                - {{.artifacts_dest_path}}/${bundle.name}/${bundle.target}/${workspace.current_user.short_name}/.internal/{{.project_name}}-assembly-{{template `version` .}}.jar

--- a/contrib/templates/scala-job/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/contrib/templates/scala-job/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -14,4 +14,4 @@ resources:
           spec:
             client: "3"
             jar_dependencies:
-                - {{.artifacts_dest_path}}/${bundle.name}/${bundle.target}/${workspace.current_user.short_name}/.internal/{{.project_name}}-assembly-{{template `version` .}}.jar
+                - ${workspace.artifact_path}/.internal/{{.project_name}}-assembly-{{template `version` .}}.jar

--- a/contrib/templates/scala-job/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/contrib/templates/scala-job/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -14,4 +14,4 @@ resources:
           spec:
             client: "3"
             jar_dependencies:
-                - ../{{template `jar_path` .}}
+                - {{.artifacts_dest_path}}/${bundle.name}/${bundle.target}/${workspace.current_user.short_name}/.internal/{{template `jar_path` .}}

--- a/contrib/templates/scala-job/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/contrib/templates/scala-job/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -8,6 +8,7 @@ resources:
         - task_key: main_task
           spark_jar_task:
             main_class_name: {{template `main_class_name` .}}
+          environment_key: default
       environments:
         - environment_key: default
           spec:

--- a/contrib/templates/scala-job/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/contrib/templates/scala-job/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -8,13 +8,9 @@ resources:
         - task_key: main_task
           spark_jar_task:
             main_class_name: {{template `main_class_name` .}}
-          libraries:
-            - jar: ../{{template `jar_path` .}}
-      queue:
-        enabled: true
       environments:
         - environment_key: default
           spec:
             client: "3"
             jar_dependencies:
-                - {{.artifacts_dest_path}}/${bundle.name}/${bundle.target}/${workspace.current_user.short_name}
+                - ../{{template `jar_path` .}}


### PR DESCRIPTION
as per title we will use serverless client image 3 environment as the default setup for job deployment with this dabs template 

test: executed manually in azure dogfood
https://adb-7064161269814046.2.staging.azuredatabricks.net/jobs/1125439312175236/runs/900250358433962?o=7064161269814046