### PR TITLE
Upgrade dbconnect to latest version + remove udfs since they don't work reliably

### DIFF
--- a/contrib/templates/scala-job/library/template_variables.tmpl
+++ b/contrib/templates/scala-job/library/template_variables.tmpl
@@ -3,7 +3,7 @@
 {{- end }}
 
 {{ define `dbr_version` -}}
-    16.3
+    16.4
 {{- end }}
 
 {{ define `scala_major_minor_version` -}}

--- a/contrib/templates/scala-job/template/{{.project_name}}/src/main/scala/com/examples/Main.scala
+++ b/contrib/templates/scala-job/template/{{.project_name}}/src/main/scala/com/examples/Main.scala
@@ -19,15 +19,7 @@ object Main {
     println("Showing nyctaxi trips ...")
     val nycTaxi = new NycTaxi(spark)
     val df = nycTaxi.trips()
-
-    // Define a simple UDF that formats the passenger count as a string
-    val testudf = udf((count: String) => s"test: $count")
-
-    // Apply the UDF to the passenger_count column
-    val transformedDF = df.withColumn("testresult", testudf(F.col("dropoff_zip")))
-
-    // Show the transformed DataFrame
-    transformedDF.show()
+    df.show()
   }
 
   def getSession(): SparkSession = {
@@ -39,6 +31,7 @@ object Main {
       println("Running outside Databricks")
       DatabricksSession.builder()
         .serverless()
+        .validateSession(false)
         .addCompiledArtifacts(Main.getClass.getProtectionDomain.getCodeSource.getLocation.toURI)
         .getOrCreate()
     }


### PR DESCRIPTION
In serverless at the moment the udfs will break once the dbconnect version is different from the server. It's easier for users not to assume udfs are working until a long term fix comes. Summary of changes and reasons:

1. Upgrade dbconnect to 16.4 from 16.3
2. validateSession(false) to no longer have strict DBConnect <-> DBR version check 
3. Remove example usage of udfs since they break everytime serverless upgrades (for now)

Ran `sbt test` 