### PR TITLE
Add example for refering to a file in alerts

### DIFF
--- a/knowledge_base/alerts/databricks.yml
+++ b/knowledge_base/alerts/databricks.yml
@@ -15,7 +15,6 @@ workspace:
   host: https://myworkspace.databricks.com
 
 
-
 targets:
   dev:
     default: true

--- a/knowledge_base/alerts/databricks.yml
+++ b/knowledge_base/alerts/databricks.yml
@@ -7,13 +7,12 @@ include:
 variables:
   # The "warehouse_id" variable is used to reference the warehouse used by the alert.
   warehouse_id:
-    default: 49efc47d56d40c50
-    # lookup:
-    #   # Replace this with the name of your SQL warehouse.
-    #   warehouse: "Shared Unity Catalog Severless"
+    lookup:
+      # Replace this with the name of your SQL warehouse.
+      warehouse: "Shared Unity Catalog Severless"
 
-# workspace:
-  # host: https://myworkspace.databricks.com
+workspace:
+  host: https://myworkspace.databricks.com
 
 
 

--- a/knowledge_base/alerts/databricks.yml
+++ b/knowledge_base/alerts/databricks.yml
@@ -7,12 +7,14 @@ include:
 variables:
   # The "warehouse_id" variable is used to reference the warehouse used by the alert.
   warehouse_id:
-    lookup:
-      # Replace this with the name of your SQL warehouse.
-      warehouse: "Shared Unity Catalog Severless"
+    default: 49efc47d56d40c50
+    # lookup:
+    #   # Replace this with the name of your SQL warehouse.
+    #   warehouse: "Shared Unity Catalog Severless"
 
-workspace:
-  host: https://myworkspace.databricks.com
+# workspace:
+  # host: https://myworkspace.databricks.com
+
 
 
 targets:

--- a/knowledge_base/alerts/resources/nyc_taxi_daily_revenue.alert.yml
+++ b/knowledge_base/alerts/resources/nyc_taxi_daily_revenue.alert.yml
@@ -58,5 +58,3 @@ resources:
       display_name: "NYC Taxi Daily Revenue Alert as File"
       warehouse_id: ${var.warehouse_id}
       file_path: ./nyc_taxi_daily_revenue_as_file.dbalert.json
-
-

--- a/knowledge_base/alerts/resources/nyc_taxi_daily_revenue.alert.yml
+++ b/knowledge_base/alerts/resources/nyc_taxi_daily_revenue.alert.yml
@@ -48,3 +48,15 @@ resources:
         pause_status: "UNPAUSED"
         quartz_cron_schedule: "0 0 8 * * ?"  # Run daily at 8 AM UTC
         timezone_id: "UTC"
+
+    # This is the same alert as above, but refers to a .dbalert.json file
+    # for the configuration.
+    nyc_taxi_daily_revenue_as_file:
+      permissions:
+        - level: CAN_MANAGE
+          user_name: user@company.com
+      display_name: "NYC Taxi Daily Revenue Alert as File"
+      warehouse_id: ${var.warehouse_id}
+      file_path: ./nyc_taxi_daily_revenue_as_file.dbalert.json
+
+

--- a/knowledge_base/alerts/resources/nyc_taxi_daily_revenue.alert.yml
+++ b/knowledge_base/alerts/resources/nyc_taxi_daily_revenue.alert.yml
@@ -52,7 +52,7 @@ resources:
     # This alert is configured identically to the above alert, but it refers to a .dbalert.json file
     # instead of inlining the configuration in YAML. We recommend inlining the configuration in YAML
     # when you need to productionize the alert across different target (dev, staging, prod) and
-    # use a .dbalert.json file when you have a single target alert that you author in the Databricks UI
+    # using a .dbalert.json file when you have a single target alert that you author in the Databricks UI
     # or using the databricks bundle generate alert command.
     nyc_taxi_daily_revenue_as_file:
       permissions:

--- a/knowledge_base/alerts/resources/nyc_taxi_daily_revenue.alert.yml
+++ b/knowledge_base/alerts/resources/nyc_taxi_daily_revenue.alert.yml
@@ -49,8 +49,8 @@ resources:
         quartz_cron_schedule: "0 0 8 * * ?"  # Run daily at 8 AM UTC
         timezone_id: "UTC"
 
-    # This is the same alert as above, but refers to a .dbalert.json file
-    # for the configuration.
+    # This alert is configured identically to the above alert, but it refers to a .dbalert.json file
+    # instead of inlining the configuration in YAML.
     nyc_taxi_daily_revenue_as_file:
       permissions:
         - level: CAN_MANAGE

--- a/knowledge_base/alerts/resources/nyc_taxi_daily_revenue.alert.yml
+++ b/knowledge_base/alerts/resources/nyc_taxi_daily_revenue.alert.yml
@@ -50,7 +50,10 @@ resources:
         timezone_id: "UTC"
 
     # This alert is configured identically to the above alert, but it refers to a .dbalert.json file
-    # instead of inlining the configuration in YAML.
+    # instead of inlining the configuration in YAML. We recommend inlining the configuration in YAML
+    # when you need to productionize the alert across different target (dev, staging, prod) and
+    # use a .dbalert.json file when you have a single target alert that you author in the Databricks UI
+    # or using the databricks bundle generate alert command.
     nyc_taxi_daily_revenue_as_file:
       permissions:
         - level: CAN_MANAGE

--- a/knowledge_base/alerts/resources/nyc_taxi_daily_revenue_as_file.dbalert.json
+++ b/knowledge_base/alerts/resources/nyc_taxi_daily_revenue_as_file.dbalert.json
@@ -1,0 +1,35 @@
+{
+  "custom_summary": "Alert when NYC Taxi daily revenue exceeds threshold",
+  "evaluation": {
+    "source": {
+      "name": "amount",
+      "display": "amount",
+      "aggregation": "MAX"
+    },
+    "comparison_operator": "GREATER_THAN",
+    "threshold": {
+      "value": {
+        "double_value": 1000000.0
+      }
+    },
+    "notification": {
+      "retrigger_seconds": 3600,
+      "notify_on_ok": false
+    }
+  },
+  "schedule": {
+    "quartz_cron_schedule": "0 0 8 * * ?",
+    "timezone_id": "UTC"
+  },
+  "query_lines": [
+    "SELECT",
+    "  to_date(tpep_pickup_datetime) as date,",
+    "  SUM(fare_amount) as amount",
+    "FROM",
+    "  `samples`.`nyctaxi`.`trips`",
+    "GROUP BY",
+    "  ALL",
+    "ORDER BY",
+    "  1 DESC"
+  ]
+}


### PR DESCRIPTION
This PR documents the second way to refer to alerts in DABs. Both alerts have identical configurations and are in the same example to make it clear that either mode is acceptable to use.

Tested using `databricks bundle validate` that this example works.