### PR TITLE
default-scala: align with Serverless environment version 4

### DIFF
--- a/contrib/templates/default-scala/library/template_variables.tmpl
+++ b/contrib/templates/default-scala/library/template_variables.tmpl
@@ -8,7 +8,7 @@
 {{- end }}
 
 {{ define `dbr_version` -}}
-    17.0
+    17.3
 {{- end }}
 
 {{ define `scala_major_minor_version` -}}

--- a/contrib/templates/default-scala/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
+++ b/contrib/templates/default-scala/template/{{.project_name}}/resources/{{.project_name}}.job.yml.tmpl
@@ -31,7 +31,7 @@ resources:
       environments:
         - environment_key: default
           spec:
-            environment_version: "4-scala-preview"
+            environment_version: "4"
             java_dependencies:
               - ${workspace.artifact_path}/.internal/{{.project_name}}-assembly-{{template `version` .}}.jar
 {{- else}}


### PR DESCRIPTION
Two single-line changes to align `default-scala` with serverless environment version 4. Without these, the template generates a project that targets a different runtime version than what the bundle deploys to.

## Changes

**1. `dbr_version`: 17.0 → 17.3** (`library/template_variables.tmpl`)

The variable feeds an sbt revision specifier of `"{{dbr_version}}.+"`, which becomes `"17.0.+"` today. sbt resolves this to the latest 17.0.x `databricks-connect` client only — customers never pick up the 17.3.x client that ships on the current Serverless control plane (env v4).

**2. `environment_version`: `"4-scala-preview"` → `"4"`** (`resources/{{.project_name}}.job.yml.tmpl`)

`default-scala` is the only bundle in this repo still on the transitional `4-scala-preview` value. Every other template (`lakeflow_pipelines_python`, `dbt_sql`, `lakeflow_pipelines_sql`, the ingestion monitoring notebooks, `pydabs`) uses plain `"4"`, which is the canonical env v4 identifier now that Scala/Java JAR support has landed.