### PR TITLE
Remove redundant base_parameters from Vector Search example jobs

### DIFF
--- a/knowledge_base/vector_search_product_discovery/resources/query-job.yml
+++ b/knowledge_base/vector_search_product_discovery/resources/query-job.yml
@@ -28,6 +28,4 @@ resources:
         - task_key: query
           environment_key: serverless_env
           notebook_task:
-            # Job parameters are pushed down to the notebook automatically;
-            # no base_parameters needed.
             notebook_path: ../src/02_query_demo.py

--- a/knowledge_base/vector_search_product_discovery/resources/query-job.yml
+++ b/knowledge_base/vector_search_product_discovery/resources/query-job.yml
@@ -28,11 +28,6 @@ resources:
         - task_key: query
           environment_key: serverless_env
           notebook_task:
+            # Job parameters are pushed down to the notebook automatically;
+            # no base_parameters needed.
             notebook_path: ../src/02_query_demo.py
-            base_parameters:
-              index_name: "{{job.parameters.index_name}}"
-              endpoint_name: "{{job.parameters.endpoint_name}}"
-              embedding_model: "{{job.parameters.embedding_model}}"
-              embedding_dimension: "{{job.parameters.embedding_dimension}}"
-              query: "{{job.parameters.query}}"
-              num_results: "{{job.parameters.num_results}}"

--- a/knowledge_base/vector_search_product_discovery/resources/setup-job.yml
+++ b/knowledge_base/vector_search_product_discovery/resources/setup-job.yml
@@ -27,8 +27,6 @@ resources:
           description: Load products from JSON, embed descriptions, and upsert into the Vector Search index
           environment_key: serverless_env
           notebook_task:
-            # Job parameters are pushed down to the notebook automatically;
-            # no base_parameters needed.
             notebook_path: ../src/01_upsert_products.py
 
       max_concurrent_runs: 1

--- a/knowledge_base/vector_search_product_discovery/resources/setup-job.yml
+++ b/knowledge_base/vector_search_product_discovery/resources/setup-job.yml
@@ -27,12 +27,8 @@ resources:
           description: Load products from JSON, embed descriptions, and upsert into the Vector Search index
           environment_key: serverless_env
           notebook_task:
+            # Job parameters are pushed down to the notebook automatically;
+            # no base_parameters needed.
             notebook_path: ../src/01_upsert_products.py
-            base_parameters:
-              index_name: "{{job.parameters.index_name}}"
-              endpoint_name: "{{job.parameters.endpoint_name}}"
-              embedding_model: "{{job.parameters.embedding_model}}"
-              embedding_dimension: "{{job.parameters.embedding_dimension}}"
-              data_path: "{{job.parameters.data_path}}"
 
       max_concurrent_runs: 1


### PR DESCRIPTION
Follow-up to [review feedback on #153](https://github.com/databricks/bundle-examples/pull/153#discussion_r3402195142): job-level `parameters` are automatically pushed down to notebook tasks, so the `base_parameters` blocks that mirrored them 1:1 via `{{job.parameters.x}}` were redundant.

Confirmed against the docs ([Parameterize jobs](https://docs.databricks.com/aws/en/jobs/parameters), [Access parameter values from a task](https://docs.databricks.com/aws/en/jobs/parameter-use)):

- Job parameters are pushed down to tasks that use key-value parameters; notebooks read them with `dbutils.widgets.get()` — which is exactly how `01_upsert_products.py` and `02_query_demo.py` already read them.
- When a task parameter and a job parameter share a name, the job parameter is fetched — so these `base_parameters` could never take effect anyway; removing them is behavior-preserving.

`databricks bundle validate` passes for both targets against a real workspace (dev and prod, host placeholder swapped locally for validation only).

This pull request and its description were generated with Claude Code.