### PR TITLE
Format geniespace to match upstream & avoid git diff when running generate

### DIFF
--- a/knowledge_base/app_with_genie_space/src/nyc_taxi_genie.geniespace.json
+++ b/knowledge_base/app_with_genie_space/src/nyc_taxi_genie.geniespace.json
@@ -1,47 +1,54 @@
 {
-  "version": 2,
   "config": {
     "sample_questions": [
       {
         "id": "11111111111111111111111111111111",
-        "question": ["What is the average fare per trip?"]
+        "question": [
+          "What is the average fare per trip?"
+        ]
       },
       {
         "id": "22222222222222222222222222222222",
-        "question": ["How many trips were longer than 10 miles?"]
+        "question": [
+          "How many trips were longer than 10 miles?"
+        ]
       }
     ]
   },
   "data_sources": {
     "tables": [
       {
-        "identifier": "samples.nyctaxi.trips",
         "column_configs": [
-          { "column_name": "dropoff_zip" },
-          { "column_name": "fare_amount" },
-          { "column_name": "pickup_zip" },
-          { "column_name": "tpep_dropoff_datetime" },
-          { "column_name": "tpep_pickup_datetime" },
-          { "column_name": "trip_distance" }
-        ]
+          {
+            "column_name": "dropoff_zip"
+          },
+          {
+            "column_name": "fare_amount"
+          },
+          {
+            "column_name": "pickup_zip"
+          },
+          {
+            "column_name": "tpep_dropoff_datetime"
+          },
+          {
+            "column_name": "tpep_pickup_datetime"
+          },
+          {
+            "column_name": "trip_distance"
+          }
+        ],
+        "identifier": "samples.nyctaxi.trips"
       }
     ]
   },
   "instructions": {
-    "text_instructions": [
-      {
-        "id": "33333333333333333333333333333333",
-        "content": [
-          "This Genie space answers questions about NYC taxi trips.\n",
-          "All data is in the samples.nyctaxi.trips table.\n",
-          "Fare amounts are in USD. When asked about revenue, use SUM(fare_amount)."
-        ]
-      }
-    ],
     "example_question_sqls": [
       {
         "id": "44444444444444444444444444444444",
-        "question": ["What was the total revenue per pickup zip code?"],
+        "question": [
+          "What was the total revenue per pickup zip code?"
+        ],
         "sql": [
           "SELECT\n",
           "  pickup_zip,\n",
@@ -51,6 +58,17 @@
           "ORDER BY total_revenue DESC"
         ]
       }
+    ],
+    "text_instructions": [
+      {
+        "content": [
+          "This Genie space answers questions about NYC taxi trips.\n",
+          "All data is in the samples.nyctaxi.trips table.\n",
+          "Fare amounts are in USD. When asked about revenue, use SUM(fare_amount)."
+        ],
+        "id": "33333333333333333333333333333333"
+      }
     ]
-  }
+  },
+  "version": 2
 }

--- a/knowledge_base/genie_space_nyc_taxi/src/nyc_taxi_genie.geniespace.json
+++ b/knowledge_base/genie_space_nyc_taxi/src/nyc_taxi_genie.geniespace.json
@@ -1,47 +1,54 @@
 {
-  "version": 2,
   "config": {
     "sample_questions": [
       {
         "id": "11111111111111111111111111111111",
-        "question": ["What is the average fare per trip?"]
+        "question": [
+          "What is the average fare per trip?"
+        ]
       },
       {
         "id": "22222222222222222222222222222222",
-        "question": ["How many trips were longer than 10 miles?"]
+        "question": [
+          "How many trips were longer than 10 miles?"
+        ]
       }
     ]
   },
   "data_sources": {
     "tables": [
       {
-        "identifier": "samples.nyctaxi.trips",
         "column_configs": [
-          { "column_name": "dropoff_zip" },
-          { "column_name": "fare_amount" },
-          { "column_name": "pickup_zip" },
-          { "column_name": "tpep_dropoff_datetime" },
-          { "column_name": "tpep_pickup_datetime" },
-          { "column_name": "trip_distance" }
-        ]
+          {
+            "column_name": "dropoff_zip"
+          },
+          {
+            "column_name": "fare_amount"
+          },
+          {
+            "column_name": "pickup_zip"
+          },
+          {
+            "column_name": "tpep_dropoff_datetime"
+          },
+          {
+            "column_name": "tpep_pickup_datetime"
+          },
+          {
+            "column_name": "trip_distance"
+          }
+        ],
+        "identifier": "samples.nyctaxi.trips"
       }
     ]
   },
   "instructions": {
-    "text_instructions": [
-      {
-        "id": "33333333333333333333333333333333",
-        "content": [
-          "This Genie space answers questions about NYC taxi trips.\n",
-          "All data is in the samples.nyctaxi.trips table.\n",
-          "Fare amounts are in USD. When asked about revenue, use SUM(fare_amount)."
-        ]
-      }
-    ],
     "example_question_sqls": [
       {
         "id": "44444444444444444444444444444444",
-        "question": ["What was the total revenue per pickup zip code?"],
+        "question": [
+          "What was the total revenue per pickup zip code?"
+        ],
         "sql": [
           "SELECT\n",
           "  pickup_zip,\n",
@@ -51,6 +58,17 @@
           "ORDER BY total_revenue DESC"
         ]
       }
+    ],
+    "text_instructions": [
+      {
+        "content": [
+          "This Genie space answers questions about NYC taxi trips.\n",
+          "All data is in the samples.nyctaxi.trips table.\n",
+          "Fare amounts are in USD. When asked about revenue, use SUM(fare_amount)."
+        ],
+        "id": "33333333333333333333333333333333"
+      }
     ]
-  }
+  },
+  "version": 2
 }


### PR DESCRIPTION
`databricks bundle deploy` followed by `databricks bundle generate` changed formatting of git-controlled files leading to unclean git diff, because the committed example used a geniespace.json from the `databricks genie get-space` response which differs from how DABs writes the geniespace.json